### PR TITLE
Add documentation for potential bug

### DIFF
--- a/R/hex.R
+++ b/R/hex.R
@@ -29,6 +29,7 @@
 #'   `stringi` is installed, otherwise [base::nchar()] with `type = "width"`.
 #' * Unicode characters such as emoji may not align perfectly across all
 #'   terminals or fonts due to rendering differences.
+#' * The backslash character does not get rendered without escaping `\\`.
 #'
 #' @return Character scalar containing the formatted hex sticker. Invisible
 #'     if `print` is `TRUE`.


### PR DESCRIPTION
``` r
hext::hext("\\")
#>   ________
#>  /   \    \
#> /          \
#> \          /
#>  \________/
```

<sup>Created on 2026-08-08 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

``` r
hext::hext("/\", " ")
#> Error in parse(text = input): <text>:1:20: unexpected string constant
#> 1: hext::hext("/\", " "
#>                        ^
```

<sup>Created on 2026-08-08 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

Also, maybe change the file name of the `hext()` function from `hex.R` to `hext.R`?